### PR TITLE
Allow pass querystring options to files.add

### DIFF
--- a/src/files/add.js
+++ b/src/files/add.js
@@ -5,7 +5,14 @@ const promisify = require('promisify-es6')
 const DAGNodeStream = require('../utils/dagnode-stream')
 
 module.exports = (send) => {
-  return promisify((files, callback) => {
+  return promisify((files, opts, callback) => {
+    if (typeof opts === 'function') {
+      callback = opts
+      opts = {}
+    }
+
+    opts = opts || {}
+
     const ok = Buffer.isBuffer(files) ||
                isStream.readable(files) ||
                Array.isArray(files)
@@ -14,7 +21,7 @@ module.exports = (send) => {
       return callback(new Error('"files" must be a buffer, readable stream, or array of objects'))
     }
 
-    const request = { path: 'add', files: files }
+    const request = { path: 'add', files: files, qs: opts }
 
     // Transform the response stream to DAGNode values
     const transform = (res, callback) => DAGNodeStream.streamToValue(send, res, callback)

--- a/src/files/create-add-stream.js
+++ b/src/files/create-add-stream.js
@@ -24,7 +24,7 @@ module.exports = (send) => {
     }
 
     ds.end = () => {
-      add(tuples, (err, res) => {
+      add(tuples, options, (err, res) => {
         if (err) {
           return ds.emit('error', err)
         }

--- a/src/utils/get-dagnode.js
+++ b/src/utils/get-dagnode.js
@@ -2,16 +2,22 @@
 
 const DAGNode = require('ipld-dag-pb').DAGNode
 const parallel = require('async/parallel')
+const CID = require('cids')
+const mh = require('multihashes')
 const streamToValue = require('./stream-to-value')
 
 module.exports = function (send, hash, callback) {
+  // Until js-ipfs supports object/get and object/data by CID
+  // we need to convert our CID or multihash hash into a multihash
+  const multihash = mh.toB58String(new CID(hash).multihash)
+
   // Retrieve the object and its data in parallel, then produce a DAGNode
   // instance using this information.
   parallel([
     function get (done) {
       send({
         path: 'object/get',
-        args: hash
+        args: multihash
       }, done)
     },
 
@@ -21,7 +27,7 @@ module.exports = function (send, hash, callback) {
       // See https://github.com/ipfs/go-ipfs/issues/1582 for more details.
       send({
         path: 'object/data',
-        args: hash
+        args: multihash
       }, done)
     }],
 

--- a/test/files.spec.js
+++ b/test/files.spec.js
@@ -45,6 +45,20 @@ describe('.files (the MFS API part)', () => {
       })
     })
 
+    it('files.add with cid-version=1 and raw-leaves=false', (done) => {
+      const expectedHash = 'zdj7Wh9x6gXdg4UAqhRYnjBTw9eJF7hvzUU4HjpnZXHYQz9jK'
+      const options = { 'cid-version': 1, 'raw-leaves': false }
+
+      ipfs.files.add(testfile, options, (err, res) => {
+        expect(err).to.not.exist()
+
+        expect(res).to.have.length(1)
+        expect(res[0].hash).to.equal(expectedHash)
+        expect(res[0].path).to.equal(expectedHash)
+        done()
+      })
+    })
+
     it('files.mkdir', (done) => {
       ipfs.files.mkdir('/test-folder', done)
     })
@@ -170,6 +184,18 @@ describe('.files (the MFS API part)', () => {
   })
 
   describe('Promise API', () => {
+    it('files.add with cid-version=1 and raw-leaves=false', () => {
+      const expectedHash = 'zdj7Wh9x6gXdg4UAqhRYnjBTw9eJF7hvzUU4HjpnZXHYQz9jK'
+      const options = { 'cid-version': 1, 'raw-leaves': false }
+
+      return ipfs.files.add(testfile, options)
+        .then((res) => {
+          expect(res).to.have.length(1)
+          expect(res[0].hash).to.equal(expectedHash)
+          expect(res[0].path).to.equal(expectedHash)
+        })
+    })
+
     it('files.mkdir', () => {
       return ipfs.files.mkdir('/test-folder')
     })


### PR DESCRIPTION
This is in preparation for `js-ipfs` support for `cid-version` and `raw-leaves`.

Adds a test that ensures these options can be passed and verifies the correct response is received.